### PR TITLE
feat protocコマンド, go_outオプションをコンテナで使えるようにDockerfileを設定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,15 @@
 FROM golang:1.18.3
+
+RUN apt-get update && apt-get install -y unzip  
+  
+RUN mkdir -p /tmp/protoc && \  
+  curl -L https://github.com/protocolbuffers/protobuf/releases/download/v21.1/protoc-21.1-linux-x86_64.zip > /tmp/protoc/protoc.zip && \  
+  cd /tmp/protoc && \  
+  unzip protoc.zip && \  
+  mv include/* /usr/local/include/ && \
+  cp /tmp/protoc/bin/protoc /usr/local/bin && \  
+  chmod go+rx /usr/local/bin/protoc && \  
+  cd /tmp && \  
+  rm -r /tmp/protoc  
+  
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+generate-example:
+	protoc --proto_path=pb --go_out=out pb/*.proto

--- a/pb/example.proto
+++ b/pb/example.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package example.protobuf;
+option go_package = "./example";
+
+message SimpleMessage {
+    uint64 id = 1;
+    string name = 2;
+}


### PR DESCRIPTION
## 本PRについて
https://github.com/teach310/genta/issues/3

Dockerfileでの
- protocのインストール
- protoc-gen-goのインストール

サンプルの実行

## Dockerfileの書き方について
https://qiita.com/kkwatanabe/items/61d750ec16044f88aebe
これを真似して、新しくした。

## protoの書き方について

一番シンプルなのを
https://qiita.com/yugui/items/87d00d77dee159e74886
から真似。

ただし、型をよりシンプルなものにしたりgo_package追加したりはしている。

go_packageは指定しないとエラー出る。「.」がなくてもエラーでる。

## Makefileのコマンドについて

https://developers.google.com/protocol-buffers/docs/reference/go-generated#invocation
を参考にする。

> The protocol buffer compiler produces Go output when invoked with the go_out flag. The argument to the go_out flag is the directory where you want the compiler to write your Go output. The compiler creates a single source file for each .proto file input. The name of the output file is created by replacing the .proto extension with .pb.go.

go_outオプションに出力先ディレクトリを指定する


