### PR TITLE
最初のプラグイン作成

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 generate-example:
 	protoc --proto_path=pb --go_out=out pb/*.proto
 
+generate-example2:
+	protoc --proto_path=pb --plugin=./protoc-gen-genta --genta_out=out pb/*.proto
+
 build:
 	go build github.com/teach310/genta/cmd/protoc-gen-genta

--- a/genta.go
+++ b/genta.go
@@ -1,10 +1,10 @@
 package genta
 
 import (
-	"github.com/teach310/genta/generator"
+	"github.com/teach310/genta/protogen"
 )
 
 func Run() error {
-	gen := &generator.Generator{}
-	return gen.Run()
+	protogen.NewPlugin().Run()
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/teach310/genta
 
 go 1.18
+
+require google.golang.org/protobuf v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/protogen/protogen.go
+++ b/protogen/protogen.go
@@ -1,0 +1,92 @@
+// 公式のcompiler/protogenパッケージはgoの生成に特化している。
+// go_packageの入力規則があるなど、縛りもきつい。
+// https://pkg.go.dev/google.golang.org/protobuf/compiler/protogen
+// ほしいのは汎用的なものなので自作する。
+// インタフェースはOptionからRunするのが違和感あるので揃えない。
+package protogen
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
+)
+
+// 標準入力を変換して標準出力に流すっていう機能をもった構造体
+type Plugin struct {
+}
+
+// オプションを渡す。
+func NewPlugin() *Plugin {
+	plugin := &Plugin{}
+	return plugin
+}
+
+// Run executes a function as a protoc plugin.
+//
+// It reads a CodeGeneratorRequest message from os.Stdin, invokes the plugin
+// function, and writes a CodeGeneratorResponse message to os.Stdout.
+//
+// If a failure occurs while reading or writing, Run prints an error to
+// os.Stderr and calls os.Exit(1).
+func (plugin *Plugin) Run() {
+	if err := plugin.run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", filepath.Base(os.Args[0]), err)
+		os.Exit(1)
+	}
+}
+
+func (plugin *Plugin) run() error {
+	in, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		return err
+	}
+	req := &pluginpb.CodeGeneratorRequest{}
+	if err := proto.Unmarshal(in, req); err != nil {
+		return err
+	}
+	resp := plugin.generate(req)
+	out, err := proto.Marshal(resp)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stdout.Write(out); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (plugin *Plugin) generate(req *pluginpb.CodeGeneratorRequest) *pluginpb.CodeGeneratorResponse {
+	protofiles := make(map[string]*ProtoFile, len(req.ProtoFile))
+	for _, fdesc := range req.ProtoFile {
+		protofile := &ProtoFile{Proto: fdesc}
+		protofiles[fdesc.GetName()] = protofile
+	}
+
+	responseFiles := make([]*pluginpb.CodeGeneratorResponse_File, 0)
+	for _, filename := range req.FileToGenerate {
+		var sb strings.Builder
+		sb.WriteString("Helo,\n")
+		sb.WriteString("World!")
+		outputPath := strings.Replace(filename, ".proto", ".pb.txt", 1)
+		content := sb.String()
+		responseFiles = append(responseFiles, &pluginpb.CodeGeneratorResponse_File{
+			Name:    proto.String(outputPath),
+			Content: proto.String(content),
+		})
+	}
+	resp := &pluginpb.CodeGeneratorResponse{
+		File: responseFiles,
+	}
+	return resp
+}
+
+type ProtoFile struct {
+	Proto *descriptorpb.FileDescriptorProto
+	// ToGenerate bool // true if we should generate code for this file TODO: 追記
+}


### PR DESCRIPTION
## 本PRについて

課題
https://github.com/teach310/genta/issues/4

必要最小限の機能として、contentはHello, World。としている。
buildしたあとmake generate-example2で使用できるようにしている。
とりあえず、generatorを介さずprotogenだけでプラグインが完結するようにしているが、そこらへんはこれから考える

## 背景
https://github.com/protocolbuffers/protobuf-go
protobuf-goには`.proto`fileからgoのコードを生成するためのpackageが用意されている。

[compiler/protogen](https://pkg.go.dev/google.golang.org/protobuf/compiler/protogen): Package protogen provides support for writing protoc plugins.

このpackageを使うと、[この記事](https://qiita.com/ffjlabo/items/54ca3f3b8079c3d5420a)のように少ないコード量でプラグインを書くことが可能。

しかし、かなりGo寄りの実装になっている。
https://github.com/protocolbuffers/protobuf-go/blob/v1.28.0/compiler/protogen/protogen.go#L386-L388

生成対象にgoを含まない、汎用的なプラグインを作るのであればこのpackageでgo用の書き方に依存すべきではないと判断。

## 本課題の設計

https://pkg.go.dev/google.golang.org/protobuf/compiler/protogen
を参考に汎用的なprotogenパッケージを作成。

genta.go -> protogen.go

のように呼び出す。

## protogenパッケージに書くこと

- (渡されたOptionの解析) 検討中
- 標準入力を読んでCodeGeneratorRequestを作る
- CodeGeneratorResponseの整形
- CodeGeneratorResponseを標準出力に出力

## CodeGeneratorRequestとは

https://github.com/protocolbuffers/protobuf-go/blob/v1.28.0/types/pluginpb/plugin.pb.go#L192

これ。
必要な情報は全部ここにある。

## CodeGeneratorResponseの作り方
https://github.com/protocolbuffers/protobuf-go/blob/v1.28.0/types/pluginpb/plugin.pb.go#L283

生成ロジックでerr出た場合はErrorに突っ込む
ファイル生成できたらFileに突っ込む

Fileは以下のように作る

```.go
		resp.File = append(resp.File, &pluginpb.CodeGeneratorResponse_File{
			Name:    proto.String(filename),
			Content: proto.String(string(content)),
		})
```

proto.Stringが何やってるのかはいまいち分かっていないが、そのまま使う。
本PRではcontentに適当な文字列をいるが、contentの生成は別packageに切り出そうと考えている。

## 本PRでやったこと
- Plugin構造体の作成
- 標準入力 -> ファイル生成 -> 標準出力という一連の流れ
- go modの更新 `go mod tidy`




