### PR TITLE
feat テンプレートファイルを使ったcontent生成

### DIFF
--- a/generator/csharp_file.go
+++ b/generator/csharp_file.go
@@ -1,0 +1,16 @@
+package generator
+
+type CSharpFile struct {
+	Namespace string
+	ClassList []*CSharpClass
+}
+
+type CSharpClass struct {
+	Name   string
+	Fields []*CSharpClassField
+}
+
+type CSharpClassField struct {
+	Name     string
+	TypeName string
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1,13 +1,23 @@
 package generator
 
 import (
-	"fmt"
+	"bytes"
+	"text/template"
 )
 
 type Generator struct {
 }
 
-func (g *Generator) Run() error {
-	fmt.Printf("Hello World\n")
-	return nil
+func (g *Generator) Run(csharpFile *CSharpFile) (string, error) {
+	filepath := "templates/example.pb.cs.tmpl"
+	tmpl, err := template.ParseFiles(filepath)
+	if err != nil {
+		return "", err
+	}
+	var buffer bytes.Buffer
+	if err := tmpl.Execute(&buffer, csharpFile); err != nil {
+		return "", err
+	}
+
+	return buffer.String(), nil
 }

--- a/pb/example.proto
+++ b/pb/example.proto
@@ -5,3 +5,8 @@ message SimpleMessage {
     uint64 id = 1;
     string name = 2;
 }
+
+message SecondMessage {
+    int64 id = 1;
+    string name = 2;
+}

--- a/templates/example.pb.cs.tmpl
+++ b/templates/example.pb.cs.tmpl
@@ -1,0 +1,15 @@
+using System.Collections;
+using System;
+
+namespace {{.Namespace}}
+{
+    {{- range .ClassList}}
+    [Serializable]
+    public class {{.Name}}
+    {
+        {{- range .Fields}}
+        public {{.TypeName}} {{.Name}};
+        {{- end}}
+    }
+    {{- end}}
+}


### PR DESCRIPTION
パス等はいったん決め打ちしてるので、後々修正していく

## 本PRについて

以下の実装

- テンプレートファイルの作成
- テンプレートの取得
- FileDescriptorProtoを流し込む値に変換
- テンプレートに値を流し込む

課題
https://github.com/teach310/genta/issues/8

## テンプレートファイルの作成について

拡張子は特に縛りはないが、一般的であるtmplを使用
https://pkg.go.dev/text/template
に構文はのってる。

繋げなければ「{」をエスケープする必要はない。

■ ループについて
indexは試していない。

`{{- range .ClassList}}`

のように指定するとできる。
内部では配列の要素が「.」となる。

■ 棒について
`{{- 構文}}`
とすると手前側の空白および改行が消える

試した結果 左棒だけでいいのではないかという気持ちになってる。

■ クラスの間に改行いれたい
多分かなり書かなくちゃいけないので諦めてdotnet-formatしたほうが良さそう。

