### PR TITLE
modify: Dockerfile arm64対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,18 @@ FROM golang:1.18.3
 
 RUN apt-get update && apt-get install -y unzip  
   
-RUN mkdir -p /tmp/protoc && \  
-  curl -L https://github.com/protocolbuffers/protobuf/releases/download/v21.1/protoc-21.1-linux-x86_64.zip > /tmp/protoc/protoc.zip && \  
-  cd /tmp/protoc && \  
-  unzip protoc.zip && \  
+RUN set -eux; \
+  arch="$(dpkg --print-architecture)"; \
+  url=; \
+  case "$arch" in \
+    'amd64') url='https://github.com/protocolbuffers/protobuf/releases/download/v21.1/protoc-21.1-linux-x86_64.zip' ;; \
+    'arm64') url='https://github.com/protocolbuffers/protobuf/releases/download/v21.1/protoc-21.1-linux-aarch_64.zip' ;; \
+    *) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+  esac; \
+  mkdir -p /tmp/protoc && \
+  curl -L "$url" > /tmp/protoc/protoc.zip && \
+  cd /tmp/protoc && \
+  unzip protoc.zip && \
   mv include/* /usr/local/include/ && \
   cp /tmp/protoc/bin/protoc /usr/local/bin && \  
   chmod go+rx /usr/local/bin/protoc && \  

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ generate-example:
 	protoc --proto_path=pb --go_out=out pb/*.proto
 
 generate-example2:
+	@mkdir -p out
 	protoc --proto_path=pb --plugin=./protoc-gen-genta --genta_out=out pb/*.proto
 
 build:


### PR DESCRIPTION
## What is this?

issue
なし

## 内容
modify: Dockerfile arm64対応

■ 背景
amd64のprotocを使用していたため、silicon端末でmake run を実行するとエラーがでるようになっていた。

■ 対応
arch="$(dpkg --print-architecture)";
でアーキテクチャを取得、caseで取得するprotocのパッケージを切り替えるようにした。

golangのほうは

```
arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
```
と書かれている。##(パターン)は(パターン)を消すための書き方だが、現状必要ではなかったため省いた。

■ 参考
golangのDockerfileの複数アーキテクチャ対応を真似した。
https://github.com/docker-library/golang/blob/ad25ff18a6fcb732a2998c89424d00aa1acc2d31/1.18/bullseye/Dockerfile#L25-L59
