### PR TITLE
オプションを渡せるようにする。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ generate-example:
 	protoc --proto_path=pb --go_out=out pb/*.proto
 
 generate-example2:
-	protoc --proto_path=pb --plugin=./protoc-gen-genta --genta_out=out pb/*.proto
+	protoc --proto_path=pb --plugin=./protoc-gen-genta --genta_opt=templates_path=templates --genta_out=out pb/*.proto
 
 build:
 	go build github.com/teach310/genta/cmd/protoc-gen-genta

--- a/cmd/protoc-gen-genta/main.go
+++ b/cmd/protoc-gen-genta/main.go
@@ -1,12 +1,21 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 
 	"github.com/teach310/genta"
+	"github.com/teach310/genta/internal/version"
 )
 
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == "--version" {
+		fmt.Fprintf(os.Stdout, "%v %v\n", filepath.Base(os.Args[0]), version.String())
+		os.Exit(0)
+	}
+
 	if err := genta.Run(); err != nil {
 		log.Fatalln(err)
 	}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -2,14 +2,16 @@ package generator
 
 import (
 	"bytes"
+	"path/filepath"
 	"text/template"
 )
 
 type Generator struct {
+	TemplatesPath string
 }
 
 func (g *Generator) Run(csharpFile *CSharpFile) (string, error) {
-	filepath := "templates/example.pb.cs.tmpl"
+	filepath := filepath.Join(g.TemplatesPath, "example.pb.cs.tmpl")
 	tmpl, err := template.ParseFiles(filepath)
 	if err != nil {
 		return "", err

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,14 @@
+package version
+
+import "fmt"
+
+const (
+	Major = 0
+	Minor = 0
+	Patch = 1
+)
+
+func String() string {
+	v := fmt.Sprintf("v%d.%d.%d", Major, Minor, Patch)
+	return v
+}

--- a/protogen/options.go
+++ b/protogen/options.go
@@ -1,0 +1,27 @@
+package protogen
+
+import "strings"
+
+type Options struct {
+	TemplatesPath string
+}
+
+// paramter CodeGeneratorRequest.GetParameterで取得できるカンマ区切りのパラメータ
+func parseOptions(parameter string) *Options {
+	options := &Options{}
+	for _, param := range strings.Split(parameter, ",") {
+		i := strings.Index(param, "=")
+		if i < 0 {
+			continue // bool値でも必ずtrue, falseを明示的に指定することを必須とする。
+		}
+
+		key := param[0:i]
+		value := param[i+1:]
+
+		switch key {
+		case "templates_path":
+			options.TemplatesPath = value
+		}
+	}
+	return options
+}

--- a/protogen/protogen.go
+++ b/protogen/protogen.go
@@ -63,6 +63,8 @@ func (plugin *Plugin) run() error {
 }
 
 func (plugin *Plugin) generate(req *pluginpb.CodeGeneratorRequest) *pluginpb.CodeGeneratorResponse {
+	options := parseOptions(req.GetParameter())
+
 	protoFiles := make(map[string]*ProtoFile, len(req.ProtoFile))
 	for _, fdesc := range req.ProtoFile {
 		protoFile := &ProtoFile{Proto: fdesc}
@@ -71,8 +73,8 @@ func (plugin *Plugin) generate(req *pluginpb.CodeGeneratorRequest) *pluginpb.Cod
 
 	responseFiles := make([]*pluginpb.CodeGeneratorResponse_File, 0)
 	for _, filename := range req.FileToGenerate {
-		contentBuilder := generator.Generator{}
 		protoFile := protoFiles[filename]
+		contentBuilder := generator.Generator{TemplatesPath: options.TemplatesPath}
 		csharpFile, err := protoFile.BuildCSharpFile()
 		if err != nil {
 			return &pluginpb.CodeGeneratorResponse{


### PR DESCRIPTION
## What is this?

issue
https://github.com/teach310/genta/issues/23

オプションを渡す機能の追加
テンプレートフォルダを指定する機能の追加
ついでにversion情報を追加

```
 --genta_opt=templates_path=templates
```

オプションはbool値でも必ず明示的に値をいれるようにする。

```
 --genta_opt=オプション名=オプション値
```

オプションを追加するときには
protogen/options.goに追加する。

