### PR TITLE
feat オプションによってcsとtxtを出し分ける機能を作成

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,10 @@ build:
 	go build github.com/teach310/genta/cmd/protoc-gen-genta
 
 run: build generate-example2
+
+debug_proto: build
+	@mkdir -p out
+	protoc --proto_path=pb --plugin=./protoc-gen-genta \
+	--genta_opt=templates_path=templates \
+	--genta_opt=model=txt \
+	--genta_out=out pb/*.proto

--- a/protogen/options.go
+++ b/protogen/options.go
@@ -3,7 +3,8 @@ package protogen
 import "strings"
 
 type Options struct {
-	TemplatesPath string
+	TemplatesPath string // .tmplファイルのあるフォルダのパス
+	Model         string // .protoをなんのモデルに変換するのかを指定。 cs, txt
 }
 
 // paramter CodeGeneratorRequest.GetParameterで取得できるカンマ区切りのパラメータ
@@ -21,6 +22,8 @@ func parseOptions(parameter string) *Options {
 		switch key {
 		case "templates_path":
 			options.TemplatesPath = value
+		case "model":
+			options.Model = value
 		}
 	}
 	return options

--- a/protogen/protogen.go
+++ b/protogen/protogen.go
@@ -67,38 +67,62 @@ func (plugin *Plugin) generate(req *pluginpb.CodeGeneratorRequest) *pluginpb.Cod
 
 	protoFiles := make(map[string]*ProtoFile, len(req.ProtoFile))
 	for _, fdesc := range req.ProtoFile {
-		protoFile := &ProtoFile{Proto: fdesc}
-		protoFiles[fdesc.GetName()] = protoFile
+		filePath := fdesc.GetName()
+		protoFile := &ProtoFile{FilePath: filePath, Proto: fdesc}
+		protoFiles[filePath] = protoFile
 	}
 
 	responseFiles := make([]*pluginpb.CodeGeneratorResponse_File, 0)
 	for _, filename := range req.FileToGenerate {
 		protoFile := protoFiles[filename]
-		contentBuilder := generator.Generator{TemplatesPath: options.TemplatesPath}
-		csharpFile, err := protoFile.BuildCSharpFile()
+		var createResponseFileFunc func(protoFile *ProtoFile, options *Options) (*pluginpb.CodeGeneratorResponse_File, error)
+		if options.Model == "txt" {
+			createResponseFileFunc = plugin.createTextResponseFile
+		} else {
+			createResponseFileFunc = plugin.createCSharpResponseFile
+		}
+		responseFile, err := createResponseFileFunc(protoFile, options)
 		if err != nil {
 			return &pluginpb.CodeGeneratorResponse{
 				Error: proto.String(err.Error()),
 			}
 		}
 
-		content, err := contentBuilder.Run(csharpFile)
-		if err != nil {
-			return &pluginpb.CodeGeneratorResponse{
-				Error: proto.String(err.Error()),
-			}
-		}
-
-		outputPath := strings.Replace(filename, ".proto", ".pb.cs", 1)
-		responseFiles = append(responseFiles, &pluginpb.CodeGeneratorResponse_File{
-			Name:    proto.String(outputPath),
-			Content: proto.String(content),
-		})
+		responseFiles = append(responseFiles, responseFile)
 	}
 	resp := &pluginpb.CodeGeneratorResponse{
 		File: responseFiles,
 	}
 	return resp
+}
+
+func (plugin *Plugin) createCSharpResponseFile(protoFile *ProtoFile, options *Options) (*pluginpb.CodeGeneratorResponse_File, error) {
+	contentBuilder := generator.Generator{TemplatesPath: options.TemplatesPath}
+	csharpFile, err := protoFile.BuildCSharpFile()
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := contentBuilder.Run(csharpFile)
+	if err != nil {
+		return nil, err
+	}
+
+	outputPath := strings.Replace(protoFile.FilePath, ".proto", ".pb.cs", 1)
+	return &pluginpb.CodeGeneratorResponse_File{
+		Name:    proto.String(outputPath),
+		Content: proto.String(content),
+	}, nil
+}
+
+func (plugin *Plugin) createTextResponseFile(protoFile *ProtoFile, options *Options) (*pluginpb.CodeGeneratorResponse_File, error) {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintln("FileDescriptorProto.GetName():", protoFile.FilePath))
+	outputPath := strings.Replace(protoFile.FilePath, ".proto", ".pb.txt", 1)
+	return &pluginpb.CodeGeneratorResponse_File{
+		Name:    proto.String(outputPath),
+		Content: proto.String(sb.String()),
+	}, nil
 }
 
 // 調査用。DescriptorProtoからの情報を文字列としてぬいて出力する
@@ -126,6 +150,7 @@ func (plugin *Plugin) getMessageInfoPrototype(messageTypes []*descriptorpb.Descr
 }
 
 type ProtoFile struct {
-	Proto *descriptorpb.FileDescriptorProto
+	FilePath string // relative
+	Proto    *descriptorpb.FileDescriptorProto
 	// ToGenerate bool // true if we should generate code for this file TODO: 追記
 }


### PR DESCRIPTION
gentaのコンセプトがproto -> model -> templateなのでprotoを何に変換するかというoptionの名前はmodelにしている。
modelのvalidationは後々必要であればいれるイメージ
createResponseFileFuncはデリゲートよりもインタフェースのほうが良いと思うが、まだ最終的にどういう形にするかがみえていないのでとりあえずコード量少ない方法で実装している。

## What is this?

issue
https://github.com/teach310/genta/issues/23

